### PR TITLE
fix: depends_on must support conditions

### DIFF
--- a/src/main/kotlin/ch/derlin/dcvizmermaid/helpers/YamlUtils.kt
+++ b/src/main/kotlin/ch/derlin/dcvizmermaid/helpers/YamlUtils.kt
@@ -5,6 +5,10 @@ import kotlin.reflect.KClass
 
 typealias YAML = Map<String, Any?>
 
+sealed class ListOrMap
+data class OrList(val list: List<String>) : ListOrMap()
+data class OrMap(val map: YAML = mapOf()) : ListOrMap()
+
 @Suppress("UNCHECKED_CAST")
 object YamlUtils {
 
@@ -16,6 +20,12 @@ object YamlUtils {
         require(value is List<*> && value.all { it is T }) { "Unexpected type for list $value" }
         value as List<T>
     } ?: default
+
+    fun YAML.getListOrMapByPath(path: String): ListOrMap? = when (val value = this.getByPath(path)) {
+        is List<*> -> OrList(value as List<String>)
+        is Map<*, *> -> OrMap(value as YAML)
+        else -> null
+    }
 
     fun <T : Any> YAML.getByPath(path: String, type: KClass<T>): T? = getByPath(path)?.let {
         require(type.isInstance(it)) { "Wrong type for $it" }
@@ -32,5 +42,5 @@ object YamlUtils {
     }
 
     // useful to avoid the "uncheck cast" warnings in the calling code
-    fun Any.asYaml(): YAML = this as YAML
+    fun Any.asYaml(): YAML = (this as? YAML) ?: mapOf()
 }

--- a/src/test/kotlin/ch/derlin/dcvizmermaid/data/ServiceTest.kt
+++ b/src/test/kotlin/ch/derlin/dcvizmermaid/data/ServiceTest.kt
@@ -3,6 +3,7 @@ package ch.derlin.dcvizmermaid.data
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import ch.derlin.dcvizmermaid.helpers.YamlUtils
 import org.junit.jupiter.api.Test
 
 class ServiceTest {
@@ -16,6 +17,36 @@ class ServiceTest {
                 "redis" to link("redis")
             ).forEach { (link, expected) ->
                 assertThat(link).transform { parseLink(it) }.isEqualTo(expected)
+            }
+        }
+    }
+
+    @Test
+    fun `parse depends_on as list or map form`() {
+
+        assertAll {
+            listOf(
+                """
+                depends_on:
+                - foo
+                - bar
+                """,
+                """
+                depends_on:
+                  foo:
+                  bar:
+                """,
+                """
+                depends_on:
+                  foo:
+                    condition: service_healthy
+                  bar:
+                    condition: service_completed_successfully
+                """
+            ).forEach { yaml ->
+                assertThat(yaml)
+                    .transform { Service("service", YamlUtils.load(yaml)).links().map { it.to } }
+                    .isEqualTo(listOf("foo", "bar"))
             }
         }
     }


### PR DESCRIPTION
The depends_on may be a list or a map depending on the docker-compose spec. It now supports both.

Closes: #4