### PR TITLE
fix: properly quote labels with dots

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,6 @@ name: Test and build
 # events but only for the master branch
 on:
   push:
-    branches: [ 'develop', 'main' ]
   pull_request:
     branches: [ main ]
 

--- a/src/main/kotlin/ch/derlin/dcvizmermaid/graph/Utils.kt
+++ b/src/main/kotlin/ch/derlin/dcvizmermaid/graph/Utils.kt
@@ -19,5 +19,5 @@ internal fun Any.toValidId(): String = toString().replace("[^a-zA-Z0-9]".toRegex
 
 internal fun Any.toValidName() =
     toString().replace("\"", "'").let {
-        if ("[\\w !?_/':,.-]*".toRegex().matchEntire(it) == null) "\"$it\"" else it
+        if ("[\\w !?_/':,-]*".toRegex().matchEntire(it) == null) "\"$it\"" else it
     }

--- a/src/test/kotlin/ch/derlin/dcvizmermaid/graph/UtilsTest.kt
+++ b/src/test/kotlin/ch/derlin/dcvizmermaid/graph/UtilsTest.kt
@@ -25,7 +25,7 @@ class UtilsTest {
             mapOf(
                 // no quotes
                 "node" to "node",
-                "/path/to/file.txt" to "/path/to/file.txt",
+                "/path/to/file.txt" to "\"/path/to/file.txt\"",
                 "some node" to "some node",
                 "some-node ?" to "some-node ?",
                 // quotes

--- a/src/test/kotlin/ch/derlin/dcvizmermaid/renderers/TestUtils.kt
+++ b/src/test/kotlin/ch/derlin/dcvizmermaid/renderers/TestUtils.kt
@@ -8,8 +8,17 @@ fun dummyGraph(): String =
         """
         services:
           web:
-            image: derlin/rickroller
+            image: derlin/rickroller:latest
+            ports:
+              - 8080:80
+            volumes:
+              - ./foo.conf:/data/.foo.conf
+              - settings:/settings
+        volumes:
+           settings:
         """.trimIndent(),
+        withPorts = true,
+        withVolumes = true,
     ).build()
 
 fun tmpFileWithExtension(extension: String) = File.createTempFile("test", extension).also { it.deleteOnExit() }


### PR DESCRIPTION
Dots are not supported anymore in labels.
This commit ensures strings with dots are properly quoted in the generated mermaid code.

Closes: #16 